### PR TITLE
Fix banner file name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ SYSTEM_MODE_EXT := Legacy
 
 ROMFS_DIR :=
 BANNER_AUDIO := meta/audio.wav
-BANNER_IMAGE := meta/banner.png
+BANNER_IMAGE := meta/banner.cgfx
 ICON := meta/icon.png
 
 # INTERNAL #


### PR DESCRIPTION
This fixes cia and 3ds build.
Requires Steveice10/buildtools#2 to be merged first, otherwise build will fail because `bannertool` treats `.cgfx` banner as a regular `.png` banner.